### PR TITLE
chore(backstage): Adding support for backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: laravel-livewire-wizard
+  description: Headless Livewire components to build wizards
+
+spec:
+  type: library
+  lifecycle: production
+  owner: SRE
+  system: Platform


### PR DESCRIPTION
# Description

## What? 

As we open up for the Backstage developer portal (backstage.staging.monta.app) we require some files to be in your repo. This includes:
* catalog-info.yaml: We use this to index your repo in backstage with the required config
* mkdocs.yaml: We use this file to generate TechDocs, from the docs folder
* .docs dir: This is where we will store documentation for the code in the future, in case it isn't already.

## Why? 

Backstage is a developer portal, you can read more about it on the notion page: https://www.notion.so/montaapp/Backstage-4e9f3e658dc64c85847290ba333876d9?pvs=4

## Context

In the context of cataloging every service we have on Backstage. 

There are some things that have to be changed manually, these changes can be found in the catalog-info.yaml:
1. metadata.labels.tier
2. metadata.links. → set Slack url
3. metadata.links. → set Notion url
4. metadata.links. → set Grafana url
5. spec.lifecycle → experimental, production, deprecated

These changes are nice to have but not super necessary, just i you have spare time to make a commit before merging the PR. 

## Type of change
I'm only adding files. 