### PR TITLE
chore: update repo ownership to match current org [SRE-314]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,9 +3,8 @@ kind: Component
 metadata:
   name: laravel-livewire-wizard
   description: Headless Livewire components to build wizards
-
 spec:
   type: library
   lifecycle: production
-  owner: SRE
-  system: Platform
+  owner: sre
+  system: platform-division


### PR DESCRIPTION
### Changes

Set squad owner and division in  to match new org structure

### Motivation

Make sure code repository ownership reflect the current organization

#### See also
- [Code ownership notion page](https://www.notion.so/montaapp/Code-ownership-58ade3fceb1e4cb89138a7fc10c5a07f)
- [Repo ownership review spreadsheet](https://docs.google.com/spreadsheets/d/1LtA1kfE7YSUBEFAbP02XnmSZp5X_eBPmea6x832VFP4/edit?gid=0#gid=0)
- [Ticket - SRE-314](https://montaapp.atlassian.net/browse/SRE-314)